### PR TITLE
Conneroisu/main

### DIFF
--- a/codex-cli/scripts/update-nix-hash.sh
+++ b/codex-cli/scripts/update-nix-hash.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-export REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 
 # Run nix build command and capture output
 build_output=$(nix build .\#codex-cli --show-trace 2>&1)
 
 # Extract the "got" hash using grep and awk
 # Look for the line containing "got:" and extract the hash
-NEW_HASH=$(echo "$build_output" | grep -A 1 "hash mismatch" | grep "got:" | awk '{print $2}')
+NEW_HASH=$(echo "$build_output" | grep "got:" | awk '{print $2}')
 
 # Check if we found a hash
 if [ -n "$NEW_HASH" ]; then
@@ -18,7 +19,7 @@ else
     echo "$build_output"
 fi
 # Update the hash in flake.nix
-sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"$NEW_HASH\"|" "$REPO_ROOT/flake.nix"
+sed -i "s|hash = \"[^\"]*\"|hash = \"$NEW_HASH\"|" "$REPO_ROOT/flake.nix"
 
 # Check if the hash was actually changed
 if [ -z "$(git diff "$REPO_ROOT/flake.nix")" ]; then

--- a/codex-cli/scripts/update-nix-hash.sh
+++ b/codex-cli/scripts/update-nix-hash.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 
-# Script to update the npmDepsHash in flake.nix when package-lock.json changes
-# This script is meant to be triggered by a GitHub Action or run manually
+export REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# Find the repository root (where the .git directory is)
-REPO_ROOT=$(git rev-parse --show-toplevel)
-cd "$REPO_ROOT"
+# Run nix build command and capture output
+build_output=$(nix build .\#codex-cli --show-trace 2>&1)
 
-# Check if package-lock.json has changed
-if [ -z "$(git diff --name-only HEAD^ HEAD 2>/dev/null | grep 'codex-cli/package-lock.json')" ]; then
-  echo "No changes to package-lock.json detected in the last commit."
-  echo "Running manual hash update..."
+# Extract the "got" hash using grep and awk
+# Look for the line containing "got:" and extract the hash
+NEW_HASH=$(echo "$build_output" | grep -A 1 "hash mismatch" | grep "got:" | awk '{print $2}')
+
+# Check if we found a hash
+if [ -n "$NEW_HASH" ]; then
+    echo "Extracted got hash: $NEW_HASH"
+else
+    echo "Could not extract got hash from build output."
+    echo "Full build output:"
+    echo "$build_output"
 fi
-
-# Calculate the new hash
-NEW_HASH=$(nix hash path "$REPO_ROOT/codex-cli" --type sha256)
-
 # Update the hash in flake.nix
-sed -i "s|npmDepsHash = \"sha256-[^\"]*\"|npmDepsHash = \"$NEW_HASH\"|" "$REPO_ROOT/flake.nix"
+sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"$NEW_HASH\"|" "$REPO_ROOT/flake.nix"
 
 # Check if the hash was actually changed
 if [ -z "$(git diff "$REPO_ROOT/flake.nix")" ]; then
@@ -32,10 +33,11 @@ if [ -n "${GITHUB_ACTIONS:-}" ]; then
 
   # Commit and push the change
   git add "$REPO_ROOT/flake.nix"
-  git commit -m "chore: Update npmDepsHash in flake.nix
+  git commit -m "chore: Update pnpm deps hash in flake.nix
 
-This automated commit updates the npmDepsHash in flake.nix to match 
-the latest package-lock.json changes."
+This automated commit updates the pnpm deps hash hash in flake.nix to match 
+the latest hash of the workspace's pnpm-lock.yaml file. This ensures that 
+Nix's store is consistent with the latest dependencies."
 
   git push
 else

--- a/flake.nix
+++ b/flake.nix
@@ -14,15 +14,95 @@
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {inherit system;};
       node = pkgs.nodejs_22;
+      pnpm = pkgs.pnpm_10;
+      version = "0.1.0"; # TODO: Version should get updated also by github aciton
+      hash = "";
+
+      buildPnpmPackageFn = {
+        pkgs,
+        lib,
+        ...
+      }: args @ {
+        # to derive pname and version
+        packageJsonPath,
+        # to provision sources additional to monorepo boilerplate
+        extraSrcs,
+        # workspace project names required for build (e.g. anything with "workspace:*" verison declaration)
+        pnpmWorkspaces ? [],
+        hash ? lib.fakeHash,
+        pnpm ? pkgs.pnpm_10,
+        ...
+      }: let
+        src = with lib.fileset; (toSource {
+          root = ./.;
+          fileset = unions (
+            [
+              ./package.json
+              ./pnpm-lock.yaml
+              ./pnpm-workspace.yaml
+            ]
+            ++ extraSrcs
+          );
+        });
+        packageJson = lib.importJSON packageJsonPath;
+        pname = packageJson.name;
+        inherit (packageJson) version;
+        pnpmDeps = pnpm.fetchDeps {
+          inherit
+            hash
+            pname
+            pnpmWorkspaces
+            src
+            version
+            ;
+        };
+      in
+        pkgs.buildNpmPackage (
+          args
+          // rec {
+            inherit
+              pname
+              pnpmDeps
+              pnpmWorkspaces
+              src
+              version
+              ;
+            npmConfigHook = pnpm.configHook;
+            npmDeps = pnpmDeps;
+          }
+        );
+
+      buildPnpmPackage = buildPnpmPackageFn {
+        inherit pkgs;
+        inherit (pkgs) lib;
+      };
     in rec {
       packages = {
-        codex-cli = pkgs.buildNpmPackage {
-          pname = "codex-cli";
-          version = "0.1.0";
-          src = ./codex-cli;
-          npmDepsHash = "sha256-UkvkaM7tvVlio0st8UA45x8wQ+q423BTzshsmdmmO2o=";
-          nodejs = node;
+        codex-cli = buildPnpmPackage {
+          inherit version hash;
+          extraSrcs = [
+            ./codex-cli
+          ];
+          packageJsonPath = ./codex-cli/package.json;
+          src = ./.;
+          buildInputs = [
+            node
+          ];
+          buildPhase = ''
+            runHook preBuild
+            echo "pnpm --filter=codex-cli run build"
+            pnpm --filter="@openai/codex" run build
+            runHook postBuild
+          '';
+          installPhase = ''
+            mkdir -p $out
+            cp -r ./codex-cli/dist $out
+          '';
+          checkPhase = ''
+            pnpm --filter=codex-cli run test
+          '';
           npmInstallFlags = ["--frozen-lockfile"];
+          pnpmWorkspaces = ["@openai/codex"];
           meta = with pkgs.lib; {
             description = "OpenAI Codex command‑line interface";
             license = licenses.asl20;
@@ -35,14 +115,12 @@
         name = "codex-cli-dev";
         buildInputs = [
           node
+          pnpm
         ];
         shellHook = ''
-          echo "Entering development shell for codex-cli"
           cd codex-cli
-          npm ci
-          npm run build
-          export PATH=$PWD/node_modules/.bin:$PATH
-          alias codex="node $PWD/dist/cli.js"
+          pnpm install --frozen-lockfile
+          echo "Entering development shell for codex-cli"
         '';
       };
       apps = {

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,8 @@
       pkgs = import nixpkgs {inherit system;};
       node = pkgs.nodejs_22;
       pnpm = pkgs.pnpm_10;
-      version = "0.1.0"; # TODO: Version should get updated also by github aciton
-      hash = "";
+      version = "0.1.0";
+      hash = "sha256-ZXX9f/MsqMN8fxTclowDdD8+gSOOhI0i+EduTJ5eM34=";
 
       buildPnpmPackageFn = {
         pkgs,

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
         # workspace project names required for build (e.g. anything with "workspace:*" verison declaration)
         pnpmWorkspaces ? [],
         hash ? lib.fakeHash,
-        pnpm ? pkgs.pnpm_10,
+        pnpm ? pnpm,
         ...
       }: let
         src = with lib.fileset; (toSource {


### PR DESCRIPTION
This pull request refactors the build process for the `codex-cli` project to replace `npm` with `pnpm`, updates the hash update script accordingly, and introduces a new reusable function for building `pnpm` packages in `flake.nix`. The changes improve consistency and maintainability by leveraging `pnpm`'s workspace features and simplifying dependency management.

### Transition to `pnpm` for Dependency Management:
* Updated the `flake.nix` file to replace `npm` with `pnpm` for dependency management. This includes defining a reusable `buildPnpmPackageFn` function to handle `pnpm` package builds and integrating it into the `codex-cli` package definition. (`[[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R17-R105)`, `[[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R118-R123)`)
* Modified the development shell configuration in `flake.nix` to use `pnpm install --frozen-lockfile` instead of `npm ci` and removed redundant commands like `npm run build`. (`[flake.nixR118-R123](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R118-R123)`)

### Updates to Hash Update Script:
* Refactored the `update-nix-hash.sh` script to extract the hash from the `nix build` output using `grep` and `awk`, ensuring compatibility with the new `pnpm` setup. (`[codex-cli/scripts/update-nix-hash.shL3-R22](diffhunk://#diff-fa8619c7eb69c05f47c65ad2d7711c72e56cf5d8d81339c5ed16c177657b5844L3-R22)`)
* Updated the commit message template in the script to reflect the switch from `npmDepsHash` to `pnpm deps hash`. (`[codex-cli/scripts/update-nix-hash.shL35-R41](diffhunk://#diff-fa8619c7eb69c05f47c65ad2d7711c72e56cf5d8d81339c5ed16c177657b5844L35-R41)`)